### PR TITLE
Apply fake streaming workaround to gpt-5

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -109,8 +109,8 @@ export const getChatCompletionStream = async (
     }
   }
 
-  if (config.model.startsWith('o1')) {
-    // For models starting with "o1", use non-streaming request
+  if (config.model.startsWith('o1') || config.model === 'gpt-5' || config.model === 'openai/gpt-5') {
+    // For models without native streaming (o1 and specific gpt-5 variants), use non-streaming request
     const response = await fetch(endpoint, {
       method: 'POST',
       headers,


### PR DESCRIPTION
Extend the fake-streaming workaround to `gpt-5` and `openai/gpt-5` models because they do not support native streaming.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cbff14c-b898-456b-a46b-4eac7a0d9d78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cbff14c-b898-456b-a46b-4eac7a0d9d78">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

